### PR TITLE
Fix grid overlap

### DIFF
--- a/src/moxel/utils.py
+++ b/src/moxel/utils.py
@@ -171,10 +171,10 @@ class Grid:
 
         if cubic_box:
             d = length / 2
-            probe_coords = np.linspace(0-d, 0+d, self.grid_size)  # Cartesian.
+            probe_coords = np.linspace(0-d, 0+d, self.grid_size, endpoint=False)  # Cartesian.
             self._simulation_box = self.structure
         else:
-            probe_coords = np.linspace(0, 1, self.grid_size)  # Fractional.
+            probe_coords = np.linspace(0, 1, self.grid_size, endpoint=False)  # Fractional.
             scale = mic_scale_factors(self.cutoff, self.structure.lattice.matrix)
             self._simulation_box = self.structure * scale
         


### PR DESCRIPTION
This fixes a bug in the current code, where grid points at the edges ($x = 1$ or $y = 1$ or $z = 1$, in fractional coordinates) are included, which leads to duplication (because they are the same as $x = 0$, etc).

Given the use of periodic boundary conditions for the voxels, duplication is wrong. It leads to give double weight to points on the faces of the cell, and leads to wrong PBC application once the voxels are processed.

`np.linspace()` accepts a `endpoint=False` optional arg, which keeps the total number of points but does not include the endpoint. See in this simple example:

```
>>> import numpy as np
>>> np.linspace(0, 1, 5)
array([0.  , 0.25, 0.5 , 0.75, 1.  ])
>>> np.linspace(0, 1, 5, endpoint=False)
array([0. , 0.2, 0.4, 0.6, 0.8])
```