### PR TITLE
New experiment: multi-LJ grid

### DIFF
--- a/src/moxel/utils.py
+++ b/src/moxel/utils.py
@@ -185,10 +185,10 @@ class Grid:
 
         if cubic_box:
             d = length / 2
-            probe_coords = np.linspace(0-d, 0+d, self.grid_size)  # Cartesian.
+            probe_coords = np.linspace(0-d, 0+d, self.grid_size, endpoint=False)  # Cartesian.
             self._simulation_box = self.structure
         else:
-            probe_coords = np.linspace(0, 1, self.grid_size)  # Fractional.
+            probe_coords = np.linspace(0, 1, self.grid_size, endpoint=False)  # Fractional.
             scale = mic_scale_factors(self.cutoff, self.structure.lattice.matrix)
             self._simulation_box = self.structure * scale
         


### PR DESCRIPTION
The idea is simple: if you're interested in multiple LJ probes, then they differ by two things:
- value of epsilon, which is a multiplicative constant in the total energy
- value of sigma, which is more complicated

But we can produce voxel grids for multiple values of sigma, in a range `(sigma_min, sigma_max, num_sigma)` when we produce a grid. This will increase the grid size, but it will not increase the grid calculation time much.

Time to generate a grid with:

- 1 sigma value (old code): 1.87 s
- 10 sigma values: 2.01 s
- 20 sigma values: 2.05 s
- 50 sigma values (extreme case): 2.43 s

The result is a multi-channel grid, with size `ngrid x ngrid x ngrid x num_sigma`.