### PR TITLE
docs(utils): align lj_potential docstring param name with signature (#15)

### DIFF
--- a/src/moxel/utils.py
+++ b/src/moxel/utils.py
@@ -212,7 +212,7 @@ class Grid:
 
         Parameters
         ----------
-        coordinates : array_like of shape (3,)
+        coords : array_like of shape (3,)
             If ``cubic_box=None`` fractional, else cartesian.
 
         Returns


### PR DESCRIPTION
Fixes #15. The Numpy-style docstring for `Grid.lj_potential` documented the parameter as `coordinates`, but the function signature uses `coords`. One-line fix.

## Test plan

- [x] AST parse of `src/moxel/utils.py` is clean
- [x] No code paths affected — comment-only change